### PR TITLE
Fixing name provided to verifier contract on deploy. No change in contracts code.

### DIFF
--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -17,7 +17,7 @@ module.exports = (deployer, network) => {
     console.log(`Deploying to network: ${network}`);
     console.log('...Coin/Token description: ', deployOptions.currencyDescriptor);
 
-    const name = 'LivingAssets Native CryptoPayments';
+    const name = deployOptions.isERC20 ? 'LivingAssets ERC20 Payments' : 'LivingAssets Native CryptoPayments';
     const version = '1';
 
     // Reuse existing EIP712Verifier unless specified in deployOptions:


### PR DESCRIPTION
* Deploy script updated: name provided to constructor in ERC20 cases fixed. 
* Solidity contracts not modified